### PR TITLE
Add env_get, env_set, env_vars builtins

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -323,7 +323,9 @@ impl Interpreter {
             },
         );
         // Process/IO builtins.
-        for name in ["args", "exit", "exec", "input"] {
+        for name in [
+            "args", "exit", "exec", "input", "env_get", "env_set", "env_vars",
+        ] {
             self.env
                 .define(name.into(), Value::Function(FnValue::Builtin(name.into())));
         }
@@ -1671,6 +1673,32 @@ impl Interpreter {
                     }
                     Err(e) => Outcome::Error(format!("input error: {e}")),
                 }
+            }
+            "env_get" => {
+                // env_get(key) -> str (empty string if not set)
+                if let Some(Value::String(key)) = args.first() {
+                    let val = std::env::var(key).unwrap_or_default();
+                    Outcome::Val(Value::String(val))
+                } else {
+                    Outcome::Error("env_get requires a string argument".into())
+                }
+            }
+            "env_set" => {
+                // env_set(key, value)
+                if let [Value::String(key), Value::String(val), ..] = args.as_slice() {
+                    // SAFETY: Forge is single-threaded; no concurrent env access.
+                    unsafe { std::env::set_var(key, val) };
+                    Outcome::Val(Value::Unit)
+                } else {
+                    Outcome::Error("env_set requires two string arguments".into())
+                }
+            }
+            "env_vars" => {
+                // env_vars() -> [[key, value], ...]
+                let pairs: Vec<Value> = std::env::vars()
+                    .map(|(k, v)| Value::Array(vec![Value::String(k), Value::String(v)]))
+                    .collect();
+                Outcome::Val(Value::Array(pairs))
             }
             _ => Outcome::Val(Value::Unit),
         }


### PR DESCRIPTION
## Summary

Add environment variable access for scripting:

- `env_get(key)` — get env var (empty string if not set)
- `env_set(key, value)` — set env var
- `env_vars()` — list all env vars as `[[key, value], ...]`

```forge
let home = env_get("HOME")
print("HOME={home}")

env_set("MY_APP_MODE", "debug")
```

## Test plan

- [x] All 319 tests pass
- [x] `forge -e 'print(env_get("HOME"))'` prints home directory
- [x] clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)