### PR TITLE
Neovim/Vim syntax highlighting for Forge

### DIFF
--- a/editors/nvim/README.md
+++ b/editors/nvim/README.md
@@ -1,0 +1,47 @@
+# Forge Syntax Highlighting for Neovim / Vim
+
+Syntax highlighting for the [Forge](https://github.com/zrrbite/forge-compiler) programming language.
+
+## Install
+
+### Manual
+
+Copy or symlink into your Vim/Neovim runtime path:
+
+```bash
+# Neovim
+mkdir -p ~/.config/nvim
+ln -s /path/to/forge-compiler/editors/nvim/ftdetect ~/.config/nvim/ftdetect
+ln -s /path/to/forge-compiler/editors/nvim/syntax ~/.config/nvim/syntax
+
+# Vim
+ln -s /path/to/forge-compiler/editors/nvim/ftdetect ~/.vim/ftdetect
+ln -s /path/to/forge-compiler/editors/nvim/syntax ~/.vim/syntax
+```
+
+### lazy.nvim
+
+```lua
+{
+  dir = "/path/to/forge-compiler/editors/nvim",
+  ft = "forge",
+}
+```
+
+### vim-plug
+
+```vim
+Plug '/path/to/forge-compiler/editors/nvim'
+```
+
+## Features
+
+- Keywords, control flow, declarations
+- Primitive and user-defined types (PascalCase)
+- Function definitions and calls
+- String interpolation (`{expr}` inside `"..."`)
+- Escape sequences
+- Comments
+- Numbers (integer and float)
+- Operators (`->`, `=>`, `..`, `?`, `@`, `::`)
+- Boolean and constant highlighting

--- a/editors/nvim/ftdetect/forge.vim
+++ b/editors/nvim/ftdetect/forge.vim
@@ -1,0 +1,1 @@
+autocmd BufRead,BufNewFile *.fg setfiletype forge

--- a/editors/nvim/syntax/forge.vim
+++ b/editors/nvim/syntax/forge.vim
@@ -1,0 +1,76 @@
+" Vim syntax file
+" Language: Forge
+" Maintainer: zrrbite
+" Latest Revision: 2026-03-30
+
+if exists("b:current_syntax")
+  finish
+endif
+
+" Keywords
+syn keyword forgeKeyword fn let mut struct impl trait enum use pub mod
+syn keyword forgeKeyword comptime spawn where
+syn keyword forgeControl if else while for in match return break continue
+syn keyword forgeSelf self Self
+
+" Booleans
+syn keyword forgeBool true false
+
+" Constants
+syn keyword forgeConstant None PI E
+
+" Constructors / variants
+syn keyword forgeConstructor Ok Err Some HashMap
+
+" Primitive types
+syn keyword forgeType i8 i16 i32 i64 i128 u8 u16 u32 u64 u128
+syn keyword forgeType f32 f64 bool str usize isize
+
+" User-defined types (PascalCase)
+syn match forgeType "\v<[A-Z][A-Za-z0-9_]*>"
+
+" Function definitions
+syn match forgeFunction "\v<fn\s+\zs[a-z_][a-zA-Z0-9_]*\ze\s*[(<]"
+
+" Function calls
+syn match forgeFuncCall "\v<[a-z_][a-zA-Z0-9_]*\ze\s*\("
+
+" Numbers
+syn match forgeNumber "\v<\d+\.\d+>"
+syn match forgeNumber "\v<\d+>"
+
+" Operators
+syn match forgeOperator "\V->"
+syn match forgeOperator "\V=>"
+syn match forgeOperator "\V.."
+syn match forgeOperator "\V..="
+syn match forgeOperator "\V?"
+syn match forgeOperator "\V@"
+syn match forgeOperator "\V::"
+
+" Comments
+syn match forgeComment "\V//\.\*$"
+
+" Strings with interpolation
+syn region forgeString start='"' end='"' contains=forgeEscape,forgeInterp
+syn match forgeEscape contained "\v\\[nrt\\\"{}0]"
+syn region forgeInterp contained matchgroup=forgeInterpDelim start="{" end="}" contains=TOP
+
+" Highlighting links
+hi def link forgeKeyword Keyword
+hi def link forgeControl Conditional
+hi def link forgeSelf Identifier
+hi def link forgeBool Boolean
+hi def link forgeConstant Constant
+hi def link forgeConstructor Type
+hi def link forgeType Type
+hi def link forgeFunction Function
+hi def link forgeFuncCall Function
+hi def link forgeNumber Number
+hi def link forgeOperator Operator
+hi def link forgeComment Comment
+hi def link forgeString String
+hi def link forgeEscape SpecialChar
+hi def link forgeInterpDelim Special
+
+let b:current_syntax = "forge"


### PR DESCRIPTION
## Summary

Vim syntax file for Forge in `editors/nvim/`.

- Keywords, control flow, declarations
- Primitive and PascalCase user types
- Function definitions and calls
- String interpolation highlighting
- Escape sequences, comments, numbers, operators
- Install via symlink, lazy.nvim, or vim-plug

Closes #41.

## Test plan

- [x] Open `.fg` file in Neovim — keywords, strings, types, comments highlighted
- [x] String interpolation `{expr}` highlighted inside strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)