### PR TITLE
VS Code: LSP integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ vec2
 .vscode/
 .idea/
 editors/vscode/*.vsix
+editors/vscode/node_modules/

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,1 +1,2 @@
 *.vsix
+node_modules/

--- a/editors/vscode/extension.js
+++ b/editors/vscode/extension.js
@@ -1,0 +1,35 @@
+const { LanguageClient, TransportKind } = require("vscode-languageclient/node");
+const vscode = require("vscode");
+
+let client;
+
+function activate(context) {
+  const config = vscode.workspace.getConfiguration("forge");
+  const lspPath = config.get("lspPath", "forge-lsp");
+
+  const serverOptions = {
+    command: lspPath,
+    transport: TransportKind.stdio,
+  };
+
+  const clientOptions = {
+    documentSelector: [{ scheme: "file", language: "forge" }],
+  };
+
+  client = new LanguageClient(
+    "forge-lsp",
+    "Forge Language Server",
+    serverOptions,
+    clientOptions
+  );
+
+  client.start();
+}
+
+function deactivate() {
+  if (client) {
+    return client.stop();
+  }
+}
+
+module.exports = { activate, deactivate };

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,0 +1,96 @@
+{
+  "name": "forge-lang",
+  "version": "0.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "forge-lang",
+      "version": "0.2.0",
+      "dependencies": {
+        "vscode-languageclient": "^9.0.1"
+      },
+      "engines": {
+        "vscode": "^1.75.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "engines": {
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "forge-lang",
   "displayName": "Forge Language",
-  "description": "Syntax highlighting for the Forge programming language",
-  "version": "0.1.0",
+  "description": "Syntax highlighting and language server for the Forge programming language",
+  "version": "0.2.0",
   "publisher": "zrrbite",
   "repository": {
     "type": "git",
@@ -11,13 +11,24 @@
   "engines": {
     "vscode": "^1.75.0"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
+  "activationEvents": [
+    "onLanguage:forge"
+  ],
+  "main": "./extension.js",
   "contributes": {
     "languages": [
       {
         "id": "forge",
-        "aliases": ["Forge", "forge"],
-        "extensions": [".fg"],
+        "aliases": [
+          "Forge",
+          "forge"
+        ],
+        "extensions": [
+          ".fg"
+        ],
         "configuration": "./language-configuration.json"
       }
     ],
@@ -27,6 +38,19 @@
         "scopeName": "source.forge",
         "path": "./syntaxes/forge.tmLanguage.json"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Forge",
+      "properties": {
+        "forge.lspPath": {
+          "type": "string",
+          "default": "forge-lsp",
+          "description": "Path to the forge-lsp binary"
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.1"
   }
 }


### PR DESCRIPTION
## Summary

VS Code extension now connects to forge-lsp for full IDE features:
- Diagnostics (errors as you type)
- Go to definition (Ctrl+Click or F12)
- Hover (show type info)

### Setup
1. Build: \`cargo build --release --bin forge-lsp\`
2. Package: \`cd editors/vscode && npm install && npx @vscode/vsce package --allow-missing-repository\`
3. Install: \`code --install-extension forge-lang-0.2.0.vsix\`
4. Configure: set \`forge.lspPath\` in VS Code settings to the full path to \`forge-lsp\`

### Implementation
- \`extension.js\`: spawns forge-lsp via \`vscode-languageclient\`
- Configurable LSP path via \`forge.lspPath\` setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)